### PR TITLE
with-open-files macro

### DIFF
--- a/files.lisp
+++ b/files.lisp
@@ -203,3 +203,17 @@ Inspired by the function of the same name in Emacs."
      :flavor flavor
      :suffix suffix
      :space space)))
+
+
+(defmacro with-open-files (args &body body)
+  "A simple macro to open one or more files providing the streams for the BODY. The ARGS is a list of `(stream filespec options*)` as supplied to WITH-OPEN-FILE."
+  (case (length args)
+    ((0)
+     `(progn ,@body))
+    ((1)
+     `(with-open-file ,(first args) ,@body))
+    (t `(with-open-file ,(first args)
+	  (with-open-files
+	      ,(rest args) ,@body)))))
+
+


### PR DESCRIPTION
Regarding the improvement proposed [here](https://gist.github.com/arademaker/50aa74e490bf2160547cb212c9a1bf05#gistcomment-3171255), after examining the macro expansion with one argument,  I tend to prefer my original approach where the case of one spec is directly expanded to WITH-OPEN-FILE.

Regarding the name discussed in #48, I can't see any reason for something similar to `let`/`let*` in this macro. Yes, in the current version it is sequential by nature, but different from `let`, each entry `(stream filespec options*)` is always independent of each other.  I don't see how the return of one entry (always a stream) can be used in the next entry (the symbol `stream` is what is bound, `filespec` and `options` can't be streams). The possibility of a "parallel" and "sequential" implementation for this macro doesn't make sense.