### PR TITLE
Allegro Compilation Fix

### DIFF
--- a/dispatch-case.lisp
+++ b/dispatch-case.lisp
@@ -6,11 +6,11 @@
 (in-package :serapeum/dispatch-case)
 
 (define-condition dispatch-case-error (type-error)
-  ((matched-types :initarg :matched-types
-                  :reader dispatch-case-error-matched-types))
+  ((matched-types-slot :initarg :matched-types
+                       :reader dispatch-case-error-matched-types))
   (:default-initargs :matched-types nil)
   (:report (lambda (c s)
-             (with-slots (matched-types) c
+             (with-slots ((matched-types matched-types-slot)) c
                (format s "Dispatch case failed after ~a step~:p~@[ (~{~a~^, ~})~]:~%"
                        (length matched-types)
                        matched-types)


### PR DESCRIPTION
Symbol `serapeum/dispatch-case::matched-types` is used as a slot name and defined as a symbol macro. Curiously, Allegro Common Lisp 10.1 fails compilation on this situation.

For example, on this code:
```
(in-package :cl-user)

(define-symbol-macro foo ())

(defclass bar ()
  ((foo)))
```

Allegro CL produces an error:

> slot-definition did not receive a valid :name initarg
>   [Condition of type SIMPLE-ERROR]

This pull request tries to add a workaround by renaming the slot name.

Thank you for reading to the end.