### PR TITLE
Follows Allegro-specific fix about trivial-cltl2:variable-information .

### DIFF
--- a/macro-tools.lisp
+++ b/macro-tools.lisp
@@ -435,8 +435,7 @@ Returns 1 when the environment cannot be accessed."
 (defun variable-type (var &optional env)
   (if (fboundp 'trivial-cltl2:variable-information)
       (let ((alist (nth-value 2 (funcall 'trivial-cltl2:variable-information var env))))
-        (or #-allegro (cdr (assoc 'type alist))
-            #+allegro (second (assoc 'type alist))
+        (or (cdr (assoc 'type alist))
             t))
       t))
 


### PR DESCRIPTION
`trivial-cltl2:variable-information` on Allegro has sometimes returned a strange type, like `((ARRAY (INTEGER 0 1) (*))))`.
This problem was fixed in [this PR](https://github.com/Zulu-Inuoe/trivial-cltl2/pull/5) .

However, I noticed https://github.com/ruricolist/serapeum/pull/47 has fixed this problem already and conflicts the fix of trivial-cltl2.

So this pull request tries to fix the confliction.

Thank you for reading.
