### PR TITLE
Fix call/string's string typecase

### DIFF
--- a/strings.lisp
+++ b/strings.lisp
@@ -40,7 +40,7 @@ are considered whitespace."
       ((eql nil)
        (with-output-to-string (s)
          (fn s)))
-      ((and string (not simple-vector))
+      ((and string (not simple-string))
        (with-output-to-string (s stream)
          (fn s)))
       (stream (fn stream)))))


### PR DESCRIPTION
A string without a fill pointer is a simple-string, not a simple-vector.