### PR TITLE
declare that this compiler macro only returns a single value

### DIFF
--- a/numbers.lisp
+++ b/numbers.lisp
@@ -272,7 +272,7 @@ result."
            :operands (list low high)))
   (if-let (type (random-range-type low high))
     `(locally (declare (notinline random-in-range))
-       (truly-the ,type
+       (truly-the (values ,type &optional)
          (random-in-range ,low ,high)))
     call))
 


### PR DESCRIPTION
This seems to produce more efficient code in SBCL