### PR TITLE
Export iota

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -380,6 +380,7 @@
    #:runs
    #:batches
    #:assort
+   #:iota
    #:single
    #:only-elt
    #:frequencies


### PR DESCRIPTION
Hello,

I believe `iota` is missing from the exported symbols.

Best,