### PR TITLE
Several nice-to-have changes in defining-types.lisp 

### DIFF
--- a/defining-types.lisp
+++ b/defining-types.lisp
@@ -321,10 +321,8 @@ some implementation tricks from `cl-algebraic-data-type'."
                                    type-name)))))
          (constructor type-name)
          (slot-names (mapcar #'first slots))
-         (conc-name
-           (symbolicate type-name '-))
          (readers
-           (mapcar (curry #'symbolicate conc-name)
+           (mapcar (curry #'symbolicate type-name '-)
                    slot-names))
          (copier-name (symbolicate 'copy- type-name)))
     `(progn
@@ -337,7 +335,6 @@ some implementation tricks from `cl-algebraic-data-type'."
            (,type-name
             ,@(unsplice (and super `(:include ,super)))
             (:constructor ,constructor ,slot-names)
-            (:conc-name ,conc-name)
             (:predicate nil)
             (:print-function
              (lambda (object stream depth)

--- a/defining-types.lisp
+++ b/defining-types.lisp
@@ -513,13 +513,13 @@ angle brackets around it."
        (locally (declare #+sbcl (sb-ext:disable-package-locks %union))
          (symbol-macrolet ((serapeum.unlocked:%union ,super))
            (declare #+sbcl (sb-ext:enable-package-locks %union))
+           (deftype ,union ()
+             ,@(unsplice docstring)
+             '(or ,@types))
            ,@(loop for type in units
                 collect `(defunit ,type))
            ,@(loop for (type . slots) in ctors
                 collect `(defconstructor ,type ,@slots))
-           (deftype ,union ()
-             ,@(unsplice docstring)
-             '(or ,@types))
            (declaim-freeze-type ,super)
            ',union)))))
 

--- a/tests/defining-types.lisp
+++ b/tests/defining-types.lisp
@@ -134,7 +134,8 @@
 (test union/maybe
   (is (subtypep (find-class 'just) (find-class '<maybe>)))
   (is (subtypep (find-class 'nothing) (find-class '<maybe>)))
-  (is (type= '(or just nothing) 'maybe))
+  (is (subtypep 'maybe '<maybe>))
+  (is (subtypep '(or just nothing) 'maybe))
   (is (= 5 (just-value (just 5))))
   (is (eq nothing nothing))
   (is (eq nothing (eval 'nothing))))
@@ -173,6 +174,35 @@
          (match-of point (rectangular 1.0 2.0)
            ((rectangular x y) (+ x y))
            (_ nil)))))
+
+(deftype unions ()
+  '(or tree liszt maybe))
+
+(test union/exhaustiveness?
+  (finishes
+    (compile nil '(lambda (e)
+                   (etypecase-of unions e
+                     (liszt) (tree) (just) (nothing)))))
+  (signals warning
+    (compile nil '(lambda (e)
+                   (etypecase-of unions e
+                     ((or liszt tree)) (just)))))
+  (finishes
+    (compile nil '(lambda (e)
+                   (etypecase-of (or unions list) e
+                     (liszt) (tree) ((or maybe cons)) (null)))))
+  (finishes
+    (compile nil '(lambda (e)
+                   (etypecase-of (or maybe kons knil) e
+                     (just) (nothing) (liszt)))))
+  (finishes
+    (compile nil '(lambda (e)
+                   (match-of (or maybe (member 42)) e
+                     ((nothing) nil) ((just v) v) (42 'life)))))
+  (signals warning
+    (compile nil '(lambda (e)
+                   (match-of (or point liszt) e
+                     ((or (polar) (rectangular))) ((kons)))))))
 
 (defconstructor dummy-constructor
   (symbol symbol)


### PR DESCRIPTION
Didn't want to open up 4 issues separately for optimizations/feature-requests.

- Includes fix for #85 . But that's separate since it's an actual bug.
- Move `deftype` in `defunion` above other type definitions to allow recursive ADTs.
- Include `super` in the `deftype` for `defunion` since compilers generate smarter code
- Don't intern the `:conc-name` symbol in `defconstructor`
