### PR TITLE
SAME: New sequence function

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -448,6 +448,7 @@
    #:char-ecase
    #:do-splits
    #:collapse-duplicates
+   #:same
    ;; Generalized arrays.
    #:shape
    #:reshape

--- a/sequences.lisp
+++ b/sequences.lisp
@@ -1892,3 +1892,12 @@ Repetitions that are not adjacent are left alone.
                              (progn
                                (bucket-push seq elt bucket)
                                (rec (1+ i) new-key)))))))))))))
+
+(defun same (key-fn seq &key (test #'eql) (start 0) end)
+  "Return true if KEY-FN returns the same value for any/all members of LIST."
+  (let (init val)
+    (do-subseq (item seq t :start start :end end)
+      (if (null init)
+          (setf val (funcall key-fn item) init t)
+          (unless (funcall test val (funcall key-fn item))
+            (return-from same nil))))))


### PR DESCRIPTION
Add a definition of the SAME function discussed in #88.

This formulation makes the key function a required positional argument and that may be controversial (alternative being a keyword argument.)