### PR TITLE
Add feature condition for WITH-COLLECTOR inlining

### DIFF
--- a/iter.lisp
+++ b/iter.lisp
@@ -116,8 +116,8 @@ can pass the collector around or return it like any other function."
                     (dolist (x xs)
                       (setf (cdr ,tail) (setf ,tail (list x))))
                     (cdr ,head))))
-         ;; This causes problem in CCL.
-         ;; (declare (inline ,collector))
+         ;; This causes problems in CCL.
+         #-ccl (declare (inline ,collector))
          ,@body
          (the list (cdr ,head))))))
 


### PR DESCRIPTION
The comment above the commented-out `inline` declaration in `with-collector` states that it causes problems specifically in CCL. This commit adds a `#-` conditional which only disables inlining the collector function in CCL, allowing other implementations to benefit from the performance gains.