### PR TITLE
Expand WITH-BOOLEAN

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -11,8 +11,7 @@
         :tcr.parse-declarations-1.0)
   (:import-from :introspect-environment
    :compiler-macroexpand :compiler-macroexpand-1
-   :constant-form-value
-                :typexpand :typexpand-1)
+   :constant-form-value :typexpand :typexpand-1)
   (:import-from :trivia :match :ematch :defpattern)
   (:import-from :trivial-file-size :file-size-in-octets)
   (:import-from :serapeum.sum :sum)
@@ -53,7 +52,8 @@
    #:output-stream
    #:with-type-dispatch
    #:vref
-   #:with-boolean
+   #:*boolean-bypass*
+   #:with-boolean #:boolean-if #:boolean-when #:boolean-unless
    #:with-subtype-dispatch
    #:with-string-dispatch
    #:with-vector-dispatch

--- a/serapeum.asd
+++ b/serapeum.asd
@@ -112,6 +112,7 @@
   :depends-on ("serapeum"
                "fiveam"
                "local-time"
+               "agnostic-lizard"
                (:feature
                 (:or :allegro :ccl :clasp :ecl :lispworks :mezzano :sbcl)
                 "atomics"))


### PR DESCRIPTION
Please let me know if the implementation is to your liking, and if `boolean-{if,when,unless}` are sane operator names. I kinda don't think so, but backwards compatibility.

One idea is to introduce `with-branching` + `branch-{if,when,unless}` as new operators, and then possibly reimplement `with-boolean` in terms of `with-branching`, but it will require your approval.

REFERENCE.md is not yet updated; do you have anything that updates it automatically based on docstrings, or should I edit all the missing line numbers manually?