### PR TITLE
Fix & muffle sbcl compiler notes and style-warnings

### DIFF
--- a/fbind.lisp
+++ b/fbind.lisp
@@ -136,9 +136,10 @@ analyze it into an environment, declarations, and a lambda."
                         temps preds)
                 nil
                 `(lambda (&rest args)
-                   (,(case fun
-                       (conjoin 'and)
-                       (disjoin 'or))
+                   (,(locally (declare #+sbcl (sb-ext:muffle-conditions sb-ext:code-deletion-note))
+                       (case fun
+                         (conjoin 'and)
+                         (disjoin 'or)))
                     ,@(loop for temp in temps
                             collect `(apply ,temp args)))))))
     ((list* 'rcurry fun args)

--- a/numbers.lisp
+++ b/numbers.lisp
@@ -34,7 +34,8 @@ can prevent optimization.")
     (#\l 'long-float)))
 
 (defun read-float-aux (stream junk-allowed type)
-  (declare (optimize (speed 3)))
+  (declare (optimize #+sbcl (speed 1)
+                     #-sbcl (speed 3)))
   #.+merge-tail-calls+
   (labels ((junk ()
              (error "Junk in string"))

--- a/octets.lisp
+++ b/octets.lisp
@@ -39,11 +39,13 @@ Defaults to little-endian order."
           (loop for i from (1- n-bytes) downto 0
                 for j from 0
                 do (setf (aref vec j)
-                         (ldb (byte 8 (* i 8)) n)))
+                         (locally (declare #+sbcl (optimize (speed 1)))
+                           (ldb (byte 8 (* i 8)) n))))
           (loop for i from 0 below n-bytes
                 for byte from 0 by 8
                 do (setf (aref vec i)
-                         (ldb (byte 8 byte) n))))
+                         (locally (declare #+sbcl (optimize (speed 1)))
+                           (ldb (byte 8 byte) n)))))
       vec)))
 
 (-> unoctets (octet-vector &key (:big-endian t)) integer)
@@ -52,7 +54,8 @@ Defaults to little-endian order."
 Defaults to little-endian order."
   (declare (octet-vector bytes)
            (inline reduce)
-           (optimize speed))
+           (optimize #+sbcl (speed 1)
+                     #-sbcl speed))
   (if big-endian
       (reduce (lambda (sum octet)
                 (+ octet (ash sum 8)))

--- a/sequences.lisp
+++ b/sequences.lisp
@@ -157,18 +157,17 @@ If SEQ is a list, this is equivalent to `dolist'."
                     do (fn (elt seq i)))))))))
 (declaim (notinline map-subseq))
 
-(define-do-macro do-subseq ((var seq &optional return
-                                 &key start
-                                 end
-                                 from-end)
-                            &body body)
-  `(locally (declare (inline map-subseq))
-     (map-subseq
-      (lambda (,var)
-        ,@body)
-      ,seq
-      ,start ,end
-      ,from-end)))
+(locally (declare #+sbcl (sb-ext:muffle-conditions style-warning))
+  (define-do-macro do-subseq ((var seq &optional return
+                                   &key start end from-end)
+                              &body body)
+    `(locally (declare (inline map-subseq))
+       (map-subseq
+        (lambda (,var)
+          ,@body)
+        ,seq
+        ,start ,end
+        ,from-end))))
 
 ;;; Define a protocol for accumulators so we can write functions like
 ;;; `assort', `partition', &c. generically.

--- a/sequences.lisp
+++ b/sequences.lisp
@@ -1810,7 +1810,7 @@ as long as SEQ is empty.
     (repeat-sequence \"\" (1+ array-dimension-limit))
     => \"\"
 "
-  (check-type n (integer 0 *))
+  #-sbcl (check-type n (integer 0 *))
   (seq-dispatch seq
     (repeat-list seq n)
     (repeat-vector seq n)

--- a/strings.lisp
+++ b/strings.lisp
@@ -45,10 +45,11 @@ are considered whitespace."
          (fn s)))
       (output-stream (fn stream)))))
 
-(defmacro with-string ((var &optional stream
-                        &key (element-type nil element-type-supplied?))
-                       &body body)
-  "Bind VAR to the character stream designated by STREAM.
+(locally (declare #+sbcl (sb-ext:muffle-conditions style-warning))
+  (defmacro with-string ((var &optional stream
+                          &key (element-type nil element-type-supplied?))
+                         &body body)
+    "Bind VAR to the character stream designated by STREAM.
 
 STREAM is resolved like the DESTINATION argument to `format': it can
 be any of t (for `*standard-output*'), nil (for a string stream), a
@@ -62,21 +63,21 @@ functions.
     (defun format-x (x &key stream)
       (with-string (s stream)
         ...))"
-  (when (constantp stream)
-    (let ((stream (eval stream)))
-      (cond ((eql stream t)
-             (return-from with-string
-               `(let ((,var *standard-output*))
-                  ,@body)))
-            ((null stream)
-             (return-from with-string
-               `(with-output-to-string (,var
-                                        ,@(and element-type-supplied?
-                                               `(:element-type ,element-type)))
-                  ,@body))))))
+    (when (constantp stream)
+      (let ((stream (eval stream)))
+        (cond ((eql stream t)
+               (return-from with-string
+                 `(let ((,var *standard-output*))
+                    ,@body)))
+              ((null stream)
+               (return-from with-string
+                 `(with-output-to-string (,var
+                                          ,@(and element-type-supplied?
+                                                 `(:element-type ,element-type)))
+                    ,@body))))))
 
-  (with-thunk (body var)
-    `(call/string #',body ,stream)))
+    (with-thunk (body var)
+      `(call/string #',body ,stream))))
 
 (defsubst blankp (seq)
   "SEQ is either empty, or consists entirely of characters that

--- a/strings.lisp
+++ b/strings.lisp
@@ -215,7 +215,7 @@ From Emacs Lisp."
                            (when end
                              (replace result separator :start1 start)))))))))))
 
-(-> string-upcase-initials (string-designator) string)
+(-> string-upcase-initials (string-designator) (values string &optional))
 (defun string-upcase-initials (string)
   "Return STRING with the first letter of each word capitalized.
 This differs from STRING-CAPITALIZE in that the other characters in


### PR DESCRIPTION
74 compiler notes:
- 64 uncertain type (while optimize speed 3)
- 1  complex type assertion
- 1  assignment prevents use of assertion from function type proclamation
- 8  code deletion

2 style-warnings:
- 2 `&OPTIONAL` and `&KEY` found in the same lambda list