### PR TITLE
Add prepend and prependf

### DIFF
--- a/lists.lisp
+++ b/lists.lisp
@@ -68,9 +68,8 @@ From Emacs Lisp."
     ≡ (append list-2 list-1)"
   (apply #'append (reverse lists)))
 
-(define-modify-macro prependf (&rest lists)
-  "Modify-macro for prepend. Prepends LISTS to the PLACE designated by the first argument."
-  prepend)
+(define-modify-macro prependf (&rest lists) prepend
+  "Modify-macro for prepend. Prepends LISTS to the PLACE designated by the first argument.")
 
 (defmacro push-end (item place &environment env)
   "Destructively push ITEM to the end of PLACE.

--- a/lists.lisp
+++ b/lists.lisp
@@ -61,6 +61,17 @@ From Emacs Lisp."
   "Like `append1', but destructive."
   (nconc list (list item)))
 
+(defsubst prepend (&rest lists)
+  "Construct and return a list by concatenating LISTS in reverse order.
+
+    (prepend list-1 list-2)
+    ≡ (append list-2 list-1)"
+  (apply #'append (reverse lists)))
+
+(define-modify-macro prependf (&rest lists)
+  "Modify-macro for prepend. Prepends LISTS to the PLACE designated by the first argument."
+  prepend)
+
 (defmacro push-end (item place &environment env)
   "Destructively push ITEM to the end of PLACE.
 Like `push', but affects the last item rather than the first.

--- a/package.lisp
+++ b/package.lisp
@@ -360,6 +360,8 @@
    #:delq
    #:append1
    #:nconc1
+   #:prepend
+   #:prependf
    #:push-end
    #:push-end-new
    #:assocar

--- a/tests/lists.lisp
+++ b/tests/lists.lisp
@@ -59,6 +59,21 @@
     (is (equal (nconc1 (list 'a 'b 'c) '(d e))
                '(a b c (d e))))))
 
+(test prepend
+  (with-notinline (prepend)
+    (is (equal (prepend) nil))
+    (is (equal (prepend '(4 5 6) '(1 2 3)) '(1 2 3 4 5 6)))
+    (is (equal (prepend '(5 6) '(3 4) '(1 2)) '(1 2 3 4 5 6)))))
+
+(test prependf
+  (with-notinline (prepend)
+    (let ((xs (list)))
+      (prependf xs '(4 5 6))
+      (is (equal xs '(4 5 6))))
+    (let ((xs (list 4 5 6)))
+      (prependf xs '(1 2 3))
+      (is (equal xs '(1 2 3 4 5 6))))))
+
 (test push-end
   (let ((xs (list)))
     (push-end 1 xs)


### PR DESCRIPTION
Addresses #142 

I experimented a bit with `preconc` and `preconcf`, but they aren't in this PR because I had a number of issues with both its design and implementation.

1. The reversing involved in these prepend definitions meant that `preconc` was mutating it's *last* argument instead of the first, which was pretty counter intuitive (at least from my perspective)
2. More confusingly, the `preconc` tests (the same as the `prepend` tests in this PR) would fully hang SBCL when wrapped in `(with-notinline (preconc) ...)` — this might be some odd undefined behavior from destructively mutating list literals in this unusual context?

Personally, I'd prefer merging this PR as is and addressing `preconc` and friends down the line, but I'm happy with whatever you think is best — I could just be missing some obvious answers here :)