### PR TITLE
Allow string designators as separators in `mapconcat`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4588,7 +4588,7 @@ If STREAM is provided, write to STREAM rather than returning a string.
 If END is provided, then insert SEPARATOR after the last string, as
 well as between strings.
 
-Equivalent to `(mapconcat #'string STRINGS (string SEPARATOR))'.
+Equivalent to `(mapconcat #'string STRINGS SEPARATOR)'.
 
 [View source](strings.lisp#L170)
 

--- a/strings.lisp
+++ b/strings.lisp
@@ -158,8 +158,8 @@ From Emacs Lisp."
   (values
    (if (emptyp seq)
        (make-string 0)
-       (let ((fun (ensure-function fun)))
-         (check-type separator string)
+       (let ((fun (ensure-function fun))
+             (separator (string separator)))
          (with-string (stream stream)
            (seq-dispatch seq
              (mapconcat/list fun seq separator stream)
@@ -177,11 +177,10 @@ If STREAM is provided, write to STREAM rather than returning a string.
 If END is provided, then insert SEPARATOR after the last string, as
 well as between strings.
 
-Equivalent to `(mapconcat #'string STRINGS (string SEPARATOR))'."
+Equivalent to `(mapconcat #'string STRINGS SEPARATOR)'."
   (if stream
       (with-string (s stream)
-        (mapconcat #'string strings (string separator)
-                   :stream s)
+        (mapconcat #'string strings separator :stream s)
         (when end
           (write-string (string separator) s)))
       (let* ((separator (coerce (string separator)


### PR DESCRIPTION
I've noticed that most string functions in Serapeum accept string designators for string-ish arguments. But then `mapconcat` only accepted strings as separators, which might be inconvenient for the character-reliant folks (which I often am one of). 

This patch fixes the string-exclusive separators in `mapconcat` by allowing any string designator. Additionally, simplify the calls to `mapconcat` and declaim its type.

@ruricolist, any reason it wasn't string designator in the first place?