### PR TITLE
fix seq-dispatch without other form

### DIFF
--- a/macro-tools.lisp
+++ b/macro-tools.lisp
@@ -239,7 +239,7 @@ directly into Lisp code:
                 ;; will be compiled to `aref', &c.
                 `(if (arrayp ,seq)
                      ,vector-form
-                     ,other-form))))
+                     ,array-form))))
     #-(or sbcl abcl ccl)
     `(if (listp ,seq) ,list-form ,vector-form)))
 


### PR DESCRIPTION
The comment suggest the right thing, however the actually code is incorrect. This patch fixes it.