### PR TITLE
Optional return values in `->`

### DIFF
--- a/types.lisp
+++ b/types.lisp
@@ -54,13 +54,13 @@ Literal keywords, numbers, and characters are also treated as `eql' type specifi
   `(function ,args ,@(when values
                        (list values))))
 
-(defmacro -> (function args &optional values)
+(defmacro -> (function (&rest args) &optional values)
   "Declaim the ftype of FUNCTION from ARGS to VALUES.
 
      (-> mod-fixnum+ (fixnum fixnum) fixnum)
      (defun mod-fixnum+ (x y) ...)"
-  `(declaim (ftype (-> ,args ,@(when values
-                                 (list values)))
+  `(declaim (ftype (-> (,@args) ,@(when values
+                                    (list values)))
                    ,function)))
 
 (defmacro declaim-freeze-type (&rest types)

--- a/types.lisp
+++ b/types.lisp
@@ -49,16 +49,19 @@ Literal keywords, numbers, and characters are also treated as `eql' type specifi
 (defpattern tuple (&rest args)
   `(list ,@args))
 
-(deftype -> (args values)
+(deftype -> (args &optional values)
   "The type of a function from ARGS to VALUES."
-  `(function ,args ,values))
+  `(function ,args ,@(when values
+                       (list values))))
 
-(defmacro -> (function args values)
+(defmacro -> (function args &optional values)
   "Declaim the ftype of FUNCTION from ARGS to VALUES.
 
      (-> mod-fixnum+ (fixnum fixnum) fixnum)
      (defun mod-fixnum+ (x y) ...)"
-  `(declaim (ftype (-> ,args ,values) ,function)))
+  `(declaim (ftype (-> ,args ,@(when values
+                                 (list values)))
+                   ,function)))
 
 (defmacro declaim-freeze-type (&rest types)
   "Declare that TYPES is not going to change.


### PR DESCRIPTION
Hi!

This PR bundles two changes:

### Making the `values` argument to the `->` macro into an optional one. 

It's often the case, especially on SBCL, that it's not possible to define a portable type that compiler will not `warn` about. Which makes `->` kind of useless if one wants to have no warnings in their code (we have such a no-warnings regression test in Nyxt). Thus the change: allowing no return values to be specified in `->`.

### Forcing the `args` of `->` to be a list.

This one is offloading part of the validity checking into the macro, instead of type checks and runtime checks. Macro argument checking errors are easier to catch and understand, while the errors down the line are much harder to make sense of. So here it is: `args` is now `(&rest args)`.

Both changes are backwards-compatible.