### PR TITLE
Chore: Import symbols instead use packages

### DIFF
--- a/package.lisp
+++ b/package.lisp
@@ -7,14 +7,106 @@
   (:export #:sum))
 
 (defpackage #:serapeum
-  (:use :cl :alexandria :split-sequence :parse-number
-        :tcr.parse-declarations-1.0)
-  (:import-from :introspect-environment
-   :compiler-macroexpand :compiler-macroexpand-1
-   :constant-form-value :typexpand :typexpand-1)
-  (:import-from :trivia :match :ematch :defpattern)
-  (:import-from :trivial-file-size :file-size-in-octets)
-  (:import-from :serapeum.sum :sum)
+  (:use :cl)
+  (:import-from #:alexandria
+		;; Binding constructs
+		#:if-let
+		#:when-let
+		#:when-let*
+		;; Definitions
+		#:define-constant
+		;; Hash tables
+		#:copy-hash-table
+		#:ensure-gethash
+		#:hash-table-values
+		#:plist-hash-table
+		;; Functions
+		#:compose
+		#:curry
+		#:disjoin
+		#:ensure-function
+		#:named-lambda
+		;; Lists
+		#:appendf
+		#:doplist
+		#:ensure-car
+		#:ensure-list
+		#:flatten
+		#:lastcar
+		#:mappend
+		#:proper-list-p
+		#:remove-from-plist
+		#:setp
+		;; Numbers
+		#:clamp
+		;; Arrays
+		#:array-index
+		#:array-length
+		;; Sequences
+		#:copy-sequence
+		#:emptyp
+		#:last-elt
+		#:ends-with-subseq
+		#:extremum
+		#:first-elt
+		#:length=
+		#:random-elt
+		#:removef
+		#:rotate
+		#:sequence-of-length-p
+		#:shuffle
+		#:starts-with-subseq
+		;; Macros
+		#:once-only
+		#:parse-body
+		#:parse-ordinary-lambda-list
+		#:with-gensyms
+		#:with-unique-names
+		;; Symbols
+		#:make-gensym-list
+		;; Strings
+		#:string-designator
+		;; Types
+		#:non-negative-integer
+		#:of-type
+		#:type=
+		;; Conditions
+		#:required-argument
+		#:ignore-some-conditions
+		#:simple-style-warning
+		#:simple-program-error
+		;; Functions
+		#:copy-stream
+		;; io
+		#:with-input-from-file
+		#:with-output-to-file
+		;; new additions
+		#:symbolicate)
+  (:import-from #:tcr.parse-declarations-1.0
+		#:map-declaration-env
+		#:filter-declaration-env
+		#:parse-declarations
+		#:build-declarations)
+  (:import-from #:split-sequence
+		#:split-sequence
+		#:split-sequence-if
+		#:split-sequence-if-not)
+  (:import-from #:parse-number
+		#:parse-number
+		#:parse-positive-real-number
+		#:parse-real-number
+		#:invalid-number
+		#:invalid-number-value
+		#:invalid-number-reason)
+  (:import-from #:introspect-environment
+		#:compiler-macroexpand #:compiler-macroexpand-1
+		#:constant-form-value #:typexpand #:typexpand-1)
+  (:import-from #:trivia
+		#:match #:ematch :defpattern)
+  (:import-from #:trivial-file-size
+		#:file-size-in-octets)
+  (:import-from #:serapeum.sum
+		#:sum)
   (:documentation "Utilities beyond Alexandria.")
   #+sb-package-locks (:lock t)
   (:export


### PR DESCRIPTION
Import necessary symbols from alexandria, split-sequence, parse-number, tcr.parse-declarations-1.0, instead of using the packages.

Loading and tests are succeeding. Hopefully there are no symbols left to import.

Maybe the exported symbols should be in the beginning now for readability?