### PR TITLE
Correct `juxt` docstring.

### DIFF
--- a/functions.lisp
+++ b/functions.lisp
@@ -319,9 +319,8 @@ be negative.)"
 (defun juxt (&rest fns)
   "Clojure's `juxt'.
 
-Return a function of one argument, which, in turn, returns a list
-where each element is the result of applying one of FNS to the
-argument.
+Return a function which returns a list where each element is the
+result of applying one of FNS to the arguments.
 
 It’s actually quite simple, but easier to demonstrate than to explain.
 The classic example is to use `juxt` to implement `partition`:


### PR DESCRIPTION
The docstring for `juxt` claimed that the resulting function takes only one argument, while the example (and the code) show it taking more than one.

I've changed the text to make it (hopefully) less confusing.